### PR TITLE
Match specified license to license in repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "git+https://github.com/DynamicYield/server-side-reference-app.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/DynamicYield/server-side-reference-app/issues"
   },


### PR DESCRIPTION
@idanbauer 

Got 7 notifications on dependabot PRs, so I opened this project and noticed the discrepancy :wink: 